### PR TITLE
patchram service delay by 8 seconds

### DIFF
--- a/recipes-android/brcm-patchram-plus/brcm-patchram-plus/patchram.service
+++ b/recipes-android/brcm-patchram-plus/brcm-patchram-plus/patchram.service
@@ -3,6 +3,7 @@ Description=Load firmware into BCM20715A1 bluetooth chip
 
 [Service]
 Type=simple
+ExecStartPre=/bin/sleep 8
 ExecStartPre=/usr/sbin/rfkill unblock bluetooth
 ExecStart=/usr/bin/brcm_patchram_plus --enable_lpm --enable_hci --no2bytes --patchram /vendor/firmware/BCM20715A1.hcd /dev/ttyHS99
 


### PR DESCRIPTION
On dory seems to be a race hazard where a patchram.service dependency is not finished when the patchram.service is executed. Delaying the service by 8 seconds is not great but helps a lot with connection issues.