### PR TITLE
increase patchram service delay to 12 seconds

### DIFF
--- a/recipes-android/brcm-patchram-plus/brcm-patchram-plus/patchram.service
+++ b/recipes-android/brcm-patchram-plus/brcm-patchram-plus/patchram.service
@@ -3,7 +3,7 @@ Description=Load firmware into BCM20715A1 bluetooth chip
 
 [Service]
 Type=simple
-ExecStartPre=/bin/sleep 8
+ExecStartPre=/bin/sleep 12
 ExecStartPre=/usr/sbin/rfkill unblock bluetooth
 ExecStart=/usr/bin/brcm_patchram_plus --baudrate 3000000 --enable_lpm --enable_hci --no2bytes --patchram /vendor/firmware/BCM20715A1.hcd /dev/ttyHS99
 


### PR DESCRIPTION
I tested 8 and 12 seconds delay for ~15 reboots each and it seems a bit better with 12 seconds. 
15 reboots is not a great sample size, but AsteroidOS/asteroid#129 seems to indicate too that an additional increase would improve the success chance.
The change is not really noticeable. When I'm able to log-in via ssh and the UI is loaded the service already runs for ~20ish seconds.